### PR TITLE
Fix dont_blame_nrpe variable name

### DIFF
--- a/tasks/setup-nrpe.yml
+++ b/tasks/setup-nrpe.yml
@@ -6,8 +6,8 @@
     regexp: '^allowed_hosts='
     line: "allowed_hosts={% for host in nrpe_allowed_hosts %}{{ host }}{% if not loop.last %},{% endif %}{% endfor %}"
 
-- name: Set dont_blame in nrpe.cfg
+- name: Set dont_blame_nrpe in nrpe.cfg
   lineinfile:
     dest: /usr/local/nagios/etc/nrpe.cfg
-    regexp: '^dont_blame='
-    line: "dont_blame={{ nrpe_dont_blame_nrpe }}"
+    regexp: '^dont_blame_nrpe='
+    line: "dont_blame_nrpe={{ nrpe_dont_blame_nrpe }}"


### PR DESCRIPTION
Hi - I could be wrong, but I think this variable is mis-named.  With `dont_blame`, there's a warning in the nrpe log on startup